### PR TITLE
sh2: maxLines as param, grep Build marks

### DIFF
--- a/vars/sh2.groovy
+++ b/vars/sh2.groovy
@@ -44,6 +44,7 @@ def call(Map cmd) {
       error("Fatal: sh2 called without any script parameter.")
     }
 
+    cmd['maxLines'] = cmd['maxLines'] ?: ( env.MAX_LINES ?: 200 )
     cmd['timestamps'] = cmd['timestamps'] ?: false
     cmd['ansiColor'] = cmd['ansiColor'] ?: true
     cmd['returnStdout'] = cmd['returnStdout'] ?: false
@@ -109,7 +110,7 @@ def call(Map cmd) {
 
       ( ${ cmd['script'] } ) 2>&1 | \
           tee >(${ filters.join('|') } >> \$WORKSPACE/$LOG_FILEPATH) | \
-          \$AWK -v offset=\${MAX_LINES:-200} \
+          \$AWK -v offset=${cmd['maxLines']} \
           '{
                if (NR <= offset) print;
                else {
@@ -175,6 +176,7 @@ def call(Map cmd) {
                 // when specific file is mentioned the target becomes root
             }
             echo "[sh2] \uD83D\uDD0E unabridged log at ${BUILD_URL}artifact/${LOG_FOLDER}/${LOG_FILENAME}"
+            sh("grep -s '[B]uild mark:' \"${LOG_FOLDER}/${LOG_FILENAME}\"")
         }
         if (error) {
           echo "ERROR: [sh2] finally: ${error}"


### PR DESCRIPTION
not sure what is good about usage of env var,
but it's bit more clumsy to use that way,
so adding also maxLines argument to sh2,
to act like any other function as it is.

sh2('maxLines': 50, 'script': 'ls -l /usr/share')

Precedence order is parameter first, if not set then env var,
if none of them then default builtin value (atm 200).

Also grep logs for our Build markers,
as sh2 broke them by hiding their output in log files
(as Groovy Postbuild Plugin's log matcher looks just in console log).

Change-Id: I1d253aa59252bdaeb733aed7a49a952294ef071d